### PR TITLE
fix settings menu and playback buttons in fullscreen

### DIFF
--- a/src/ui/layers/lay2.module.css
+++ b/src/ui/layers/lay2.module.css
@@ -3,6 +3,7 @@
   top: 0px;
   width: 50dvw;
   height: 100dvh;
+  pointer-events: none;
 
   transition: var(--transition);
 }

--- a/src/ui/ui.module.css
+++ b/src/ui/ui.module.css
@@ -8,3 +8,57 @@
   width: 100dvw;
   height: 100dvh;
 }
+
+.configModal {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background-color: #282828;
+  border-radius: 8px;
+  padding: 24px;
+  width: 420px;
+  max-height: 70dvh;
+  overflow-y: auto;
+  z-index: 9999;
+  color: #fff;
+  box-shadow: 0 16px 48px rgba(0, 0, 0, 0.6);
+  pointer-events: auto;
+  cursor: default;
+}
+
+.configModal::-webkit-scrollbar {
+  width: 8px;
+}
+
+.configModal::-webkit-scrollbar-thumb {
+  background-color: #535353;
+  border-radius: 4px;
+}
+
+.configHeader {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+}
+
+.configTitle {
+  font-size: 1.5rem;
+  font-weight: bold;
+}
+
+.configClose {
+  background: transparent;
+  border: none;
+  color: #b3b3b3;
+  font-size: 1.2rem;
+  cursor: pointer;
+  padding: 4px 8px;
+  border-radius: 4px;
+}
+
+.configClose:hover {
+  color: #fff;
+  background-color: #ffffff1a;
+}

--- a/src/ui/ui.tsx
+++ b/src/ui/ui.tsx
@@ -12,9 +12,9 @@ import ExternalSupport from "./lib/ExternalSupport";
 export default function UI() {
   const React = Spicetify.React;
   const { useEffect, useState, useRef } = React;
-  const ReactDOM = Spicetify.ReactDOM;
 
   const [open, setOpen] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
   const [color, setColor] = useState("#ffffff");
   const [pointerShown, setPointerShown] = useState(true);
   const pointerTimeout = useRef(null as number | null);
@@ -27,6 +27,7 @@ export default function UI() {
 
   useEffect(() => {
     if (open) document.documentElement.requestFullscreen();
+    if (!open) setConfigOpen(false);
   }, [open]);
 
   const handleDoubleClick = () => {
@@ -36,14 +37,7 @@ export default function UI() {
 
   const handleContextMenu: MouseEventHandler = (e) => {
     e.preventDefault();
-    const modalContainer = document.createElement("div");
-    ReactDOM.createRoot(modalContainer).render(
-      React.createElement(ConfigOverlay, {}),
-    );
-    Spicetify.PopupModal.display({
-      title: "Config",
-      content: modalContainer,
-    });
+    setConfigOpen((v) => !v);
   };
 
   const handlePointerMove = () => {
@@ -77,6 +71,22 @@ export default function UI() {
       <NextMusicLayer />
       <ClockLayer />
       <ExternalSupport open={open} />
+      {configOpen && (
+        <div
+          className={s.configModal}
+          onClick={(e) => e.stopPropagation()}
+          onDoubleClick={(e) => e.stopPropagation()}
+          onContextMenu={(e) => e.stopPropagation()}
+        >
+          <div className={s.configHeader}>
+            <span className={s.configTitle}>Config</span>
+            <button className={s.configClose} onClick={() => setConfigOpen(false)}>
+              ✕
+            </button>
+          </div>
+          <ConfigOverlay />
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Settings menu now renders inline inside the fullscreen container instead of using Spicetify.PopupModal which was hidden behind the fullscreen overlay. Playback buttons were unclickable because the lyrics layer blocked pointer events, added pointer-events: none to the lyrics container.